### PR TITLE
Helpers.VisPos Fix

### DIFF
--- a/src/lnxLib/TF2/Helpers.lua
+++ b/src/lnxLib/TF2/Helpers.lua
@@ -59,7 +59,7 @@ end
 ---@param to Vector3
 ---@return boolean
 function Helpers.VisPos(target, from, to)
-    local trace = engine.TraceLine(from, to, MASK_SHOT | CONTENTS_GRATE)
+    local trace = engine.TraceLine(from, to, (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_MONSTER|CONTENTS_WINDOW|CONTENTS_DEBRIS|0x40000000) | CONTENTS_GRATE)
     return (trace.entity == target) or (trace.fraction > 0.99)
 end
 

--- a/src/lnxLib/TF2/Helpers.lua
+++ b/src/lnxLib/TF2/Helpers.lua
@@ -59,7 +59,7 @@ end
 ---@param to Vector3
 ---@return boolean
 function Helpers.VisPos(target, from, to)
-    local trace = engine.TraceLine(from, to, (CONTENTS_SOLID|CONTENTS_MOVEABLE|CONTENTS_MONSTER|CONTENTS_WINDOW|CONTENTS_DEBRIS|0x40000000) | CONTENTS_GRATE)
+    local trace = engine.TraceLine(from, to,  (0x1|0x4000|0x2000000|0x2|0x4000000|0x40000000) | CONTENTS_GRATE)
     return (trace.entity == target) or (trace.fraction > 0.99)
 end
 


### PR DESCRIPTION
This is my first ever making a pull request, so please pardon any of my unprofessionalism.

MASK_SHOT has been broken in a recent lmaobox.net update, so what I have done is replaced MASK_SHOT in the VisPos function with what it is defined as instead of the now undefined variable. This seems to have fixed it.

Either way, if it was actually an accident on lmaobox's part or not, here is a fix to consider. 

![image_2023-08-17_010037024](https://github.com/lnx00/Lmaobox-Library/assets/54870332/6641f0c4-995f-43cc-bb47-835f30a9b061)
