### PR TITLE
fix inffinite loop bug

### DIFF
--- a/src/lnxLib/Utils/Logger.lua
+++ b/src/lnxLib/Utils/Logger.lua
@@ -13,14 +13,16 @@ local Logger = {
     Name = "",
     Level = 1
 }
-Logger.__index = Logger
-setmetatable(Logger, Logger)
+
+-- Correct metatable assignment using a separate metatable
+local Logger_mt = {__index = Logger}
+setmetatable(Logger, Logger_mt)
 
 -- Creates a new logger
 ---@param name string
 ---@return Logger
 function Logger.new(name)
-    local self = setmetatable({}, Logger)
+    local self = setmetatable({}, Logger_mt)
     self.Name = name
     self.Level = 1
 


### PR DESCRIPTION
To fix the infinite loop issue caused by the misuse of setmetatable in your Lua logging utility, you need to modify how the metatable is being assigned to the Logger table. The issue is that the Logger table sets its metatable to itself (Logger), which creates a recursive loop whenever you attempt to access an undefined field, eventually leading to a stack overflow.